### PR TITLE
Gems saved locally to save time building Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore mysql data
 /db_data/*
 
+# Ignore gems saved locally
+/box/*
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -3,8 +3,9 @@ FROM ruby:2.4.0
 # Installing NodeJS for some Ruby gems needed by Rails
 RUN apt-get update && apt-get install -y nodejs
 
-COPY . /var/www/site
+RUN mkdir /app
+WORKDIR /app
 
-WORKDIR /var/www/site
+ENV BUNDLE_PATH /app/box
 
-RUN bundle install
+ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.rails
-    working_dir: /var/www/site
+    working_dir: /app
+    command: /bin/bash ./entrypoint.sh
     # Removing server.pid first so Rails doesn't think there is another server running
-    command: /bin/bash -c "bash entrypoint.sh && bundle exec rails s -p 3000"
     environment:
       - MAILCHIMP_API_KEY
       - MAILCHIMP_LIST_ID
     volumes:
-      - .:/var/www/site
+      - .:/app
     ports:
       - "3000:3000"
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,3 +3,7 @@
 if [ -f "tmp/pids/server.pid" ]; then
     rm tmp/pids/server.pid
 fi
+
+bundle check || bundle install
+
+bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
### Problem
Gems were saved in the container image at build time, so adding a new gem to the Gemfile meant you have to rebuild the image.

### Solution
Gems are saved in the `box` directory, which is accessed by bundler to save and execute gems. The `box` directory is simply a volume connected to your local machine, so the gems are persisted and do not have to be installed for every build.

On `docker-compose up` the `entrypoint.sh` script also checks for uninstalled gems in the Gemfile and installs them before starting the server.